### PR TITLE
Add $not/$nor, LogicalCompilerError, and TypeScript declarations (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-29
+
+### Added
+
+- `$not` and `$nor` operators. `$not: expr` returns the negation of the expression; `$nor: [exprs]` returns the negation of `$or` over the array. Both inherit the evaluator's sync/async and short-circuit behavior. (#5)
+- `LogicalCompilerError`, a named `Error` subclass carrying a `.code` field (`UNRECOGNIZED_OPERATOR`, `UNDEFINED_FUNCTION`, `UNEXPECTED_TOKEN`, `UNEXPECTED_RETURN_TYPE`, `EXPECTED_EXPRESSION`). Existing `.message` strings are unchanged and `instanceof Error` still holds. Exposed as `compile.LogicalCompilerError`. (#6)
+- TypeScript declarations (`index.d.ts`) describing `compile`, `Options` (`fns`), `Expression`, and `LogicalCompilerError`, wired up via the `types` field in `package.json`. (#7)
+
 ## [0.2.0] - 2026-05-18
 
 ### Added
@@ -22,5 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release: MongoDB-like boolean expression compiler with `$and` / `$or` operators, callbacks, and user-defined functions.
 
+[0.3.0]: https://github.com/mutaimwiti/logical-compiler/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/mutaimwiti/logical-compiler/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/mutaimwiti/logical-compiler/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `$not` and `$nor` operators. `$not: expr` returns the negation of the expression; `$nor: [exprs]` returns the negation of `$or` over the array. Both inherit the evaluator's sync/async and short-circuit behavior. (#5)
 - `LogicalCompilerError`, a named `Error` subclass carrying a `.code` field (`UNRECOGNIZED_OPERATOR`, `UNDEFINED_FUNCTION`, `UNEXPECTED_TOKEN`, `UNEXPECTED_RETURN_TYPE`, `EXPECTED_EXPRESSION`). Existing `.message` strings are unchanged and `instanceof Error` still holds. Exposed as `compile.LogicalCompilerError`. (#6)
 - TypeScript declarations (`index.d.ts`) describing `compile`, `Options` (`fns`), `Expression`, and `LogicalCompilerError`, wired up via the `types` field in `package.json`. (#7)
+- Implicit AND across the keys of an object expression, at any nesting depth. `{ $or: [...], isAdmin: x }` now evaluates as `$or AND isAdmin` instead of silently using only the first key. (#10)
+
+### Changed
+
+- An object expression with multiple keys is now AND-ed together instead of evaluating only the first key. This changes the result of multi-key expressions that previously relied on the silent truncation. (#10)
+
+### Fixed
+
+- An empty object expression (`{}`) now throws a `LogicalCompilerError` (`EXPECTED_EXPRESSION`) instead of a raw `TypeError`. (#10)
 
 ## [0.2.0] - 2026-05-18
 

--- a/README.md
+++ b/README.md
@@ -127,21 +127,12 @@ compile(expression); // Error: Unexpected token '201'
 
 ### Callbacks
 
-#### Simple callback
+A callback is a function that returns a boolean. If it returns a promise,
+`compile` resolves to a promise you `await`.
 
 ```javascript
 let cb = () => true;
 compile(cb); // true
-
-cb = () => false;
-compile(cb); // false
-```
-
-#### Promise callback
-
-```javascript
-cb = () => Promise.resolve(true);
-await compile(cb); //true
 
 cb = () => Promise.resolve(false);
 await compile(cb); // false
@@ -159,38 +150,20 @@ await compile(expression); // true
 
 ### Functions
 
-#### Simple function
+A function is defined on the `fns` attribute of the `options` argument. It may
+return a boolean or a promise.
 
 ```javascript
 const options = {
   fns: {
     isEven: (number) => number % 2 === 0,
-  },
-};
-
-let expression = { isEven: 7 };
-compile(expression, options); // false
-
-expression = { isEven: 6 };
-compile(expression, options); // true
-```
-
-> Note that the function is defined on the `fns` attribute of the `options` argument.
-
-#### Promise function
-
-```javascript
-const options = {
-  fns: {
     isEqual: (num1, num2) => Promise.resolve(num1 === num2),
   },
 };
 
-expression = { isEqual: [3, 3] };
-await compile(expression, options); // true
+compile({ isEven: 6 }, options); // true
 
-expression = { isEqual: [3, 5] };
-await compile(expression, options); // false
+await compile({ isEqual: [3, 5] }, options); // false
 ```
 
 #### Nested promise function

--- a/README.md
+++ b/README.md
@@ -65,6 +65,31 @@ expression = { $or: [false, false] };
 compile(expression); // false
 ```
 
+#### NOT operator
+
+`$not` takes a single expression and returns its negation.
+
+```javascript
+let expression = { $not: true };
+compile(expression); // false
+
+expression = { $not: { $and: [true, true] } };
+compile(expression); // false
+```
+
+#### NOR operator
+
+`$nor` takes an array and returns the negation of `$or` over it, i.e. `true`
+only when every operand is `false`.
+
+```javascript
+let expression = { $nor: [false, false] };
+compile(expression); // true
+
+expression = { $nor: [false, true] };
+compile(expression); // false
+```
+
 #### Unrecognized operator
 ```javascript
 const expression = { $someOp: ['x', 'y'] };
@@ -279,6 +304,32 @@ compile(expression, options); // true
    Relying on truthiness would pose a serious loophole because the executable might accidentally resolve to true on a 
    non-boolean value. If the library encounters a callback that resolves to a non-boolean value, it throws an exception. 
    See [MDN](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) documentation on truthy values.
+
+### Error handling
+
+All errors thrown by `compile` are instances of `LogicalCompilerError`, a
+subclass of `Error` that carries a `.code` field for programmatic handling. The
+human-readable `.message` is unchanged.
+
+```javascript
+import compile from 'logical-compiler';
+
+try {
+  compile({ $unknown: [] });
+} catch (error) {
+  error instanceof compile.LogicalCompilerError; // true
+  error.code; // 'UNRECOGNIZED_OPERATOR'
+}
+```
+
+Codes: `UNRECOGNIZED_OPERATOR`, `UNDEFINED_FUNCTION`, `UNEXPECTED_TOKEN`,
+`UNEXPECTED_RETURN_TYPE`, `EXPECTED_EXPRESSION`.
+
+### TypeScript
+
+Type declarations ship with the package, so no separate `@types` install is
+needed. The supporting types `compile.Expression`, `compile.Options`, and
+`compile.LogicalCompilerError` are available for use in your own code.
 
 ### Licence
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,31 @@ compile(expression, options); // true
 
 > Operators can be nested in any fashion to achieve the desired logical check.
 
+### Multiple keys (implicit AND)
+
+When an object expression has more than one key, the keys are AND-ed together,
+at any nesting depth. This applies to operators and functions alike.
+
+```javascript
+const options = {
+  fns: {
+    isEven: (number) => number % 2 === 0,
+  },
+};
+
+let expression = { $or: [false, true], isEven: 6 };
+compile(expression, options); // true  ($or AND isEven)
+
+expression = { $or: [false, true], isEven: 7 };
+compile(expression, options); // false ($or is true, but isEven is false)
+```
+
+An empty object is not a valid expression and throws:
+
+```javascript
+compile({}); // Error: Expected an expression
+```
+
 ##### IMPORTANT NOTES
 
 1. `compile` returns `boolean` for fully synchronous expressions and `Promise<boolean>` when any callback or

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,38 @@
+declare function compile(
+  expression: compile.Expression,
+  options?: compile.Options,
+): boolean | Promise<boolean>;
+
+declare namespace compile {
+  type Callback = () => boolean | Promise<boolean>;
+
+  type Fn = (...args: any[]) => boolean | Promise<boolean>;
+
+  type Expression =
+    | boolean
+    | Callback
+    | { $and: Expression[] }
+    | { $or: Expression[] }
+    | { $nor: Expression[] }
+    | { $not: Expression }
+    | { [fn: string]: any };
+
+  interface Options {
+    fns?: Record<string, Fn>;
+  }
+
+  type ErrorCode =
+    | 'UNRECOGNIZED_OPERATOR'
+    | 'UNDEFINED_FUNCTION'
+    | 'UNEXPECTED_TOKEN'
+    | 'UNEXPECTED_RETURN_TYPE'
+    | 'EXPECTED_EXPRESSION';
+
+  class LogicalCompilerError extends Error {
+    constructor(message: string, code: ErrorCode);
+    name: 'LogicalCompilerError';
+    code: ErrorCode;
+  }
+}
+
+export = compile;

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "logical-compiler",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Compile MongoDB-like boolean expressions based on boolean operators AND and OR",
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
-    "/lib"
+    "/lib",
+    "/index.d.ts"
   ],
   "scripts": {
     "lint": "eslint .",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { createException } from './utils';
+import { createException, LogicalCompilerError } from './utils';
 
 const getFnArgs = (value) => (Array.isArray(value) ? value : [value]);
 
@@ -6,6 +6,7 @@ const assertBoolean = (value, type) => {
   if (typeof value !== 'boolean') {
     throw createException(
       `Unexpected return type [${typeof value}] from a ${type}`,
+      'UNEXPECTED_RETURN_TYPE',
     );
   }
 
@@ -47,14 +48,20 @@ const stepAll = (items, evaluate, shortCircuitOn) => {
   return step();
 };
 
+// Negation that preserves the sync/async contract: a sync child negates
+// immediately, a promise child negates once it resolves.
+const negate = (r) => (r instanceof Promise ? r.then((v) => !v) : !r);
+
 const operators = {
   $and: (items, evaluate) => stepAll(items, evaluate, false),
   $or: (items, evaluate) => stepAll(items, evaluate, true),
+  $not: (value, evaluate) => negate(evaluate(value)),
+  $nor: (items, evaluate) => negate(stepAll(items, evaluate, true)),
 };
 
-module.exports = (expression, options = {}) => {
+const compile = (expression, options = {}) => {
   if (expression === undefined) {
-    throw createException('Expected an expression');
+    throw createException('Expected an expression', 'EXPECTED_EXPRESSION');
   }
 
   const { fns = {} } = options;
@@ -65,7 +72,7 @@ module.exports = (expression, options = {}) => {
     if (typeof exp === 'function') return executeFunction('callback', exp);
 
     if (!exp || typeof exp !== 'object') {
-      throw createException(`Unexpected token '${exp}'`);
+      throw createException(`Unexpected token '${exp}'`, 'UNEXPECTED_TOKEN');
     }
 
     const [key, value] = Object.entries(exp)[0];
@@ -76,11 +83,11 @@ module.exports = (expression, options = {}) => {
     }
 
     if (key) {
-      const message = key.startsWith('$')
-        ? `Unrecognized operator: '${key}'`
-        : `Undefined function: '${key}'`;
+      const [message, code] = key.startsWith('$')
+        ? [`Unrecognized operator: '${key}'`, 'UNRECOGNIZED_OPERATOR']
+        : [`Undefined function: '${key}'`, 'UNDEFINED_FUNCTION'];
 
-      throw createException(message);
+      throw createException(message, code);
     }
 
     return false;
@@ -88,3 +95,7 @@ module.exports = (expression, options = {}) => {
 
   return evaluate(expression);
 };
+
+compile.LogicalCompilerError = LogicalCompilerError;
+
+module.exports = compile;

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,25 @@ const compile = (expression, options = {}) => {
       throw createException(`Unexpected token '${exp}'`, 'UNEXPECTED_TOKEN');
     }
 
-    const [key, value] = Object.entries(exp)[0];
+    const entries = Object.entries(exp);
+
+    if (entries.length === 0) {
+      throw createException('Expected an expression', 'EXPECTED_EXPRESSION');
+    }
+
+    // Multiple keys are implicitly AND-ed together (e.g. { $or: [...], fn: x }
+    // means $or AND fn), at any nesting depth. Each entry is evaluated as its
+    // own single-key expression, reusing the short-circuit AND walker so
+    // sync/async handling and short-circuit come for free.
+    if (entries.length > 1) {
+      return stepAll(
+        entries.map(([k, v]) => ({ [k]: v })),
+        evaluate,
+        false,
+      );
+    }
+
+    const [key, value] = entries[0];
 
     if (key in operators) return operators[key](value, evaluate);
     if (key in fns) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,10 @@
-export const createException = (message) => {
-  return Error(`[logical-compiler]: ${message}`);
-};
+export class LogicalCompilerError extends Error {
+  constructor(message, code) {
+    super(`[logical-compiler]: ${message}`);
+    this.name = 'LogicalCompilerError';
+    this.code = code;
+  }
+}
+
+export const createException = (message, code) =>
+  new LogicalCompilerError(message, code);

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -1,0 +1,68 @@
+import compile from '../src';
+import { LogicalCompilerError } from '../src/utils';
+
+describe('LogicalCompilerError', () => {
+  it('is exposed on the public export', () => {
+    expect(compile.LogicalCompilerError).toBe(LogicalCompilerError);
+  });
+
+  it('is an Error subclass carrying a code and prefixed message', () => {
+    const error = new LogicalCompilerError('boom', 'SOME_CODE');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(LogicalCompilerError);
+    expect(error.name).toEqual('LogicalCompilerError');
+    expect(error.code).toEqual('SOME_CODE');
+    expect(error.message).toEqual('[logical-compiler]: boom');
+  });
+
+  describe('thrown by compile', () => {
+    const cases = [
+      {
+        name: 'missing expression',
+        run: () => compile(),
+        code: 'EXPECTED_EXPRESSION',
+        message: '[logical-compiler]: Expected an expression',
+      },
+      {
+        name: 'invalid token',
+        run: () => compile('nope'),
+        code: 'UNEXPECTED_TOKEN',
+        message: "[logical-compiler]: Unexpected token 'nope'",
+      },
+      {
+        name: 'unrecognized operator',
+        run: () => compile({ $someOp: [] }),
+        code: 'UNRECOGNIZED_OPERATOR',
+        message: "[logical-compiler]: Unrecognized operator: '$someOp'",
+      },
+      {
+        name: 'undefined function',
+        run: () => compile({ someFn: [] }),
+        code: 'UNDEFINED_FUNCTION',
+        message: "[logical-compiler]: Undefined function: 'someFn'",
+      },
+      {
+        name: 'non-boolean return type',
+        run: () => compile(() => 'foo'),
+        code: 'UNEXPECTED_RETURN_TYPE',
+        message:
+          '[logical-compiler]: Unexpected return type [string] from a callback',
+      },
+    ];
+
+    cases.forEach(({ name, run, code, message }) => {
+      it(`sets code ${code} for ${name}`, () => {
+        expect.assertions(3);
+
+        try {
+          run();
+        } catch (error) {
+          expect(error).toBeInstanceOf(LogicalCompilerError);
+          expect(error.code).toEqual(code);
+          expect(error.message).toEqual(message);
+        }
+      });
+    });
+  });
+});

--- a/test/multiKey.test.js
+++ b/test/multiKey.test.js
@@ -1,0 +1,65 @@
+import compile from '../src';
+import { createException } from '../src/utils';
+
+describe('multi-key expressions (implicit AND)', () => {
+  it('ANDs the keys of an object together', () => {
+    expect(compile({ $and: [true], $or: [false] })).toEqual(false);
+    expect(compile({ $and: [true], $or: [true] })).toEqual(true);
+    expect(compile({ $or: [true], $not: false })).toEqual(true);
+    expect(compile({ $or: [true], $not: true })).toEqual(false);
+  });
+
+  it('ANDs operators with functions', () => {
+    const options = { fns: { isEven: (n) => n % 2 === 0 } };
+
+    expect(compile({ $and: [true, true], isEven: 6 }, options)).toEqual(true);
+    expect(compile({ $and: [true, true], isEven: 7 }, options)).toEqual(false);
+  });
+
+  it('applies at any nesting depth', () => {
+    const options = { fns: { gt: (a, b) => a > b } };
+    const expression = {
+      $or: [false, { $and: [true], gt: [5, 3] }],
+    };
+    expect(compile(expression, options)).toEqual(true);
+
+    expression.$or[1].gt = [1, 3]; // now the nested AND is false
+    expect(compile(expression, options)).toEqual(false);
+  });
+
+  describe('short-circuit', () => {
+    it('stops at the first falsy key and skips later ones', () => {
+      const spy = jest.fn(() => true);
+      const result = compile(
+        { $and: [false], later: spy },
+        { fns: { later: spy } },
+      );
+      expect(result).toEqual(false);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('returning promise', () => {
+    it('resolves the implicit AND across async keys', async () => {
+      const options = {
+        fns: { roleIs: (r) => Promise.resolve(r === 'admin') },
+      };
+
+      expect(
+        await compile({ $or: [false, true], roleIs: 'admin' }, options),
+      ).toEqual(true);
+
+      expect(
+        await compile({ $or: [false, true], roleIs: 'guest' }, options),
+      ).toEqual(false);
+    });
+  });
+
+  describe('empty object', () => {
+    it('throws a clean error', () => {
+      expect(() => compile({})).toThrow(
+        createException('Expected an expression', 'EXPECTED_EXPRESSION'),
+      );
+    });
+  });
+});

--- a/test/nor.test.js
+++ b/test/nor.test.js
@@ -1,0 +1,46 @@
+import compile from '../src';
+
+describe('NOR expressions', () => {
+  it('should return true only when every operand is false', () => {
+    expect(compile({ $nor: [false, false] })).toEqual(true);
+    expect(compile({ $nor: [false, true] })).toEqual(false);
+    expect(compile({ $nor: [true, false] })).toEqual(false);
+    expect(compile({ $nor: [true, true] })).toEqual(false);
+  });
+
+  it('should be the negation of $or for callbacks', () => {
+    expect(compile({ $nor: [() => false, () => false] })).toEqual(true);
+    expect(compile({ $nor: [() => false, () => true] })).toEqual(false);
+  });
+
+  it('should handle nested operator expressions', () => {
+    const expression = {
+      $nor: [false, { $and: [true, false] }],
+    };
+    expect(compile(expression)).toEqual(true);
+  });
+
+  it('$nor of [] should be true (negation of empty $or)', () => {
+    expect(compile({ $nor: [] })).toEqual(true);
+  });
+
+  describe('returning promise', () => {
+    it('should negate the resolved $or', async () => {
+      expect(
+        await compile({ $nor: [false, () => Promise.resolve(false)] }),
+      ).toEqual(true);
+
+      expect(
+        await compile({ $nor: [false, () => Promise.resolve(true)] }),
+      ).toEqual(false);
+    });
+  });
+
+  describe('short-circuit', () => {
+    it('stops after the first truthy operand and skips later items', () => {
+      const spy = jest.fn(() => true);
+      expect(compile({ $nor: [true, spy] })).toEqual(false);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/not.test.js
+++ b/test/not.test.js
@@ -1,0 +1,36 @@
+import compile from '../src';
+
+describe('NOT expressions', () => {
+  it('should negate a primitive', () => {
+    expect(compile({ $not: true })).toEqual(false);
+    expect(compile({ $not: false })).toEqual(true);
+  });
+
+  it('should negate a callback', () => {
+    expect(compile({ $not: () => true })).toEqual(false);
+    expect(compile({ $not: () => false })).toEqual(true);
+  });
+
+  it('should negate a nested operator expression', () => {
+    expect(compile({ $not: { $and: [true, true] } })).toEqual(false);
+    expect(compile({ $not: { $or: [false, false] } })).toEqual(true);
+  });
+
+  describe('returning promise', () => {
+    it('should negate the resolved value', async () => {
+      expect(await compile({ $not: () => Promise.resolve(true) })).toEqual(
+        false,
+      );
+      expect(await compile({ $not: () => Promise.resolve(false) })).toEqual(
+        true,
+      );
+    });
+
+    it('should negate a nested async expression', async () => {
+      const expression = {
+        $not: { $or: [false, () => Promise.resolve(true)] },
+      };
+      expect(await compile(expression)).toEqual(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

v0.3.0 feature bundle.

- **#5** Add `$not` (single-expression negation) and `$nor` (negation of `$or` over an array). Both reuse the existing `stepAll` short-circuit walker, so they inherit the evaluator's sync/async and short-circuit behavior.
- **#6** Add `LogicalCompilerError`, a named `Error` subclass carrying a `.code` field (`UNRECOGNIZED_OPERATOR`, `UNDEFINED_FUNCTION`, `UNEXPECTED_TOKEN`, `UNEXPECTED_RETURN_TYPE`, `EXPECTED_EXPRESSION`). Existing `.message` strings and `instanceof Error` are preserved; exposed as `compile.LogicalCompilerError`.
- **#7** Ship `index.d.ts` describing `compile`, `Options` (`fns`), `Expression`, and `LogicalCompilerError`; wire up the `types` field in `package.json`.
- **#10** Treat multi-key object expressions as implicit AND at any nesting depth (reusing the short-circuit AND walker), instead of silently evaluating only the first key. Also fixes an empty object `{}`, which now throws `LogicalCompilerError` (`EXPECTED_EXPRESSION`) instead of a raw `TypeError`.
- Document the new operators, multi-key behavior, error handling, and TypeScript support in the README; add a CHANGELOG entry and bump the version to `0.3.0`.

## Testing

- `yarn lint` clean
- `yarn test` green (60 tests; new `not`, `nor`, `error`, `multiKey` suites)
- Note: `index.d.ts` was not machine-typechecked (no TypeScript toolchain available); its runtime contract is covered by `test/error.test.js`.

Closes #5
Closes #6
Closes #7
Closes #10